### PR TITLE
Change typealias Id from Int to String

### DIFF
--- a/Sources/StravaSwift/Router.swift
+++ b/Sources/StravaSwift/Router.swift
@@ -16,7 +16,7 @@ import SwiftyJSON
  **/
 public enum Router {
 
-    public typealias Id = Int
+    public typealias Id = String
     public typealias Params = [String: Any]?
 
     /**


### PR DESCRIPTION
ID for Strava `gear` (aka 'equipment') is a String, not Int. Router does no arithmetic on the ID and the value is only interpolated into a String for the Strava HTTP requests so the library still compiles and works with this change. THIS IS A BREAKING CHANGE for programs that call the `request` function as the embedded ID parameter needs to change from Int to String - however it's a simple change from `id: id` to `id: "\(id)"`